### PR TITLE
set Fallback-Values to 0 and add Timeout for requests.get

### DIFF
--- a/dbus-tasmota-smartmeter.py
+++ b/dbus-tasmota-smartmeter.py
@@ -114,6 +114,8 @@ class DbusSmartmeterService:
       self._dbusservice['/Ac/L1/Voltage'] = 230
       self._dbusservice['/Ac/L1/Current'] = 0
       self._dbusservice['/Ac/L1/Power'] = 0
+      self._dbusservice['/Connected'] = 0
+
      # return true, otherwise add_timeout will be removed from GObject - see docs http://library.isr.ist.utl.pt/docs/pygtk2reference/gobject-functions.html#function-gobject--timeout-add
     return True
  

--- a/dbus-tasmota-smartmeter.py
+++ b/dbus-tasmota-smartmeter.py
@@ -70,7 +70,7 @@ class DbusSmartmeterService:
   
     try:
       meter_url = "http://192.168.XXX.XXX/cm?cmnd=status%2010"
-      meter_r = requests.get(url=meter_url) # request data from the Tasmota Smartmeter
+      meter_r = requests.get(url=meter_url, timeout=5) # request data from the Tasmota Smartmeter
       meter_data = meter_r.json() # convert JSON data
       #meter_consumption = meter_data['StatusSNS']['MT681']['DJ_TPWRCURR']['DJ_TPWRIN']['DJ_TPWROUT']
       #send data to DBus
@@ -107,7 +107,13 @@ class DbusSmartmeterService:
       self._lastUpdate = time.time()              
     except Exception as e:
       logging.critical('Error at %s', '_update', exc_info=e)
-       
+
+     # deliver 0 if script could not get any value from tasmota to avoid victron to use old value instead
+      self._dbusservice['/Ac/Power'] = 0
+      self._dbusservice['/Ac/Current'] = 0
+      self._dbusservice['/Ac/L1/Voltage'] = 230
+      self._dbusservice['/Ac/L1/Current'] = 0
+      self._dbusservice['/Ac/L1/Power'] = 0
      # return true, otherwise add_timeout will be removed from GObject - see docs http://library.isr.ist.utl.pt/docs/pygtk2reference/gobject-functions.html#function-gobject--timeout-add
     return True
  


### PR DESCRIPTION
**Fix stale dbus values when Tasmota device is unreachable**

 **Problem**

  When the Tasmota device becomes unreachable (e.g. WiFi dropout), requests.get() blocks the GLib MainLoop for up to ~120 seconds (default TCP timeout). During this time:

  - No new values are published to dbus
  - The last known power consumption value remains on the bus
  - The Victron ESS continues to operate based on stale data
  - Even after the device comes back online, the blocked MainLoop prevents timely recovery

  Changes

  1. Added timeout=5 to requests.get()

     Ensures the HTTP request fails fast instead of blocking the entire event loop. The timer continues to fire every second, allowing immediate recovery once the device is reachable again.

  2. Reset power values to 0 on error

     When a request fails, power and current values are set to 0 so the ESS does not continue operating on outdated grid meter data.

  Affected values on error

  ┌────────────────┬───────┐
  │ Path                                  │ Value         │
  ├────────────────┼───────┤
  │ /Ac/Power                        │ 0                │
  ├────────────────┼───────┤
  │ /Ac/Current                      │ 0               │
  ├────────────────┼───────┤
  │ /Ac/L1/Voltage                 │ 230           │ 
  ├────────────────┼───────┤
  │ /Ac/L1/Current                 │ 0               │
  ├────────────────┼───────┤
  │ /Ac/L1/Power                   │ 0                │
  └────────────────┴───────┘

  Energy counters (/Ac/Energy/Forward, /Ac/Energy/Reverse) are intentionally left unchanged since total energy does not change when no measurement is available.